### PR TITLE
Fix truncated TransactionInstruction

### DIFF
--- a/memecoin_launchpad_with_fees.py
+++ b/memecoin_launchpad_with_fees.py
@@ -494,3 +494,7 @@ class EnhancedMemecoinLaunchpad:
                 AccountMeta(pubkey=mint, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=mint_authority, is_signer=True, is_writable=False),
                 AccountMeta(pubkey=payer, is_signer=True, is_writable=True),
+                AccountMeta(pubkey=update_authority, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=SYS_PROGRAM_ID, is_signer=False, is_writable=False),
+            ]
+        )


### PR DESCRIPTION
## Summary
- restore missing accounts and closing brackets at end of `_create_enhanced_metadata_instruction`
- ensure the file compiles

## Testing
- `python -m py_compile memecoin_launchpad_with_fees.py`


------
https://chatgpt.com/codex/tasks/task_e_685022e2f1b883278143650eab60256f