### PR TITLE
Add optional Helius API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npm install
 ```bash
 cp launch-fun-frontend/.env.local.example launch-fun-frontend/.env.local
 # Edit .env.local with your configuration
-# To enable AI tagline generation, provide NEXT_PUBLIC_OPENAI_API_KEY
+# To enable AI tagline generation, provide NEXT_PUBLIC_OPENAI_API_KEY. Optionally set NEXT_PUBLIC_HELIUS_API_KEY for a dedicated RPC endpoint
 ```
 
 ### Running the Application

--- a/launch-fun-frontend/.env.local.example
+++ b/launch-fun-frontend/.env.local.example
@@ -12,3 +12,5 @@ NEXT_PUBLIC_LAUNCH_FEE=0
 
 # Optional: OpenAI API key for AI features
 NEXT_PUBLIC_OPENAI_API_KEY=
+# Optional: Helius API key for dedicated RPC
+NEXT_PUBLIC_HELIUS_API_KEY=


### PR DESCRIPTION
## Summary
- allow setting a Helius API key via `.env.local.example`
- document the optional `NEXT_PUBLIC_HELIUS_API_KEY` in the README

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_685022eabe088327842692f7d5e3120a