### PR TITLE
Remove swcMinify from Next.js config

### DIFF
--- a/launch-fun-frontend/next.config.js
+++ b/launch-fun-frontend/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
   images: {
     domains: ['localhost', 'api.launch.fun'], // Add your image domains here
   },


### PR DESCRIPTION
## Summary
- clean up `launch-fun-frontend/next.config.js` by removing the unused `swcMinify` option

## Testing
- `pytest -q` *(fails: cannot import name 'ContractName' from 'eth_typing')*


------
https://chatgpt.com/codex/tasks/task_e_685028287e3083279e005e438214ac6b