### PR TITLE
Implement buy API and update QuickBuyModal

### DIFF
--- a/launch-fun-frontend/app/api/tokens/[mint]/buy/route.ts
+++ b/launch-fun-frontend/app/api/tokens/[mint]/buy/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest, { params }: { params: { mint: string } }) {
+  try {
+    const body = await request.json()
+    const { amount, slippage, buyer } = body
+    console.log('Buy request', { mint: params.mint, amount, slippage, buyer })
+    // TODO: Integrate with backend/Raydium to create real transaction
+    // For now, return a placeholder base64 transaction string
+    const dummyTx = Buffer.from('dummy transaction').toString('base64')
+    return NextResponse.json({ transaction: dummyTx })
+  } catch (error) {
+    console.error('Buy API error:', error)
+    return NextResponse.json(
+      { error: 'Failed to create buy transaction' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add buy API route scaffold
- implement real buy logic in `QuickBuyModal` including connection checks and transaction signing

## Testing
- `npm run build` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6850284d5ef483278963602e7f9777c0