### PR TITLE
Use shared constant for metadata program

### DIFF
--- a/launch-fun-frontend/test-metadata.js
+++ b/launch-fun-frontend/test-metadata.js
@@ -1,7 +1,5 @@
 const { Connection, PublicKey } = require('@solana/web3.js');
-
-// Metaplex Token Metadata Program ID
-const TOKEN_METADATA_PROGRAM_ID = new PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');
+const { MPL_TOKEN_METADATA_PROGRAM_ID: TOKEN_METADATA_PROGRAM_ID } = require('@metaplex-foundation/mpl-token-metadata');
 
 // Helper to get metadata PDA
 function getMetadataPDA(mint) {


### PR DESCRIPTION
## Summary
- deduplicate constant in test script by importing from mpl-token-metadata
- leave route handler as-is

## Testing
- `npm run build -- --no-lint` *(fails: invalid GET export)*

------
https://chatgpt.com/codex/tasks/task_e_685028247a748327891a247669c9aea6