### PR TITLE
Remove Ape Fun header text

### DIFF
--- a/launch-fun-frontend/components/Header.tsx
+++ b/launch-fun-frontend/components/Header.tsx
@@ -40,9 +40,6 @@ export const Header: FC = () => {
                 alt="Ape Fun Logo"
                 className="w-20 h-20 mr-3"
               />
-              <h1 className="text-3xl font-bold bg-gradient-to-r from-yellow-500 via-yellow-400 to-white bg-clip-text text-transparent">
-                Ape Fun
-              </h1>
               <span className="ml-2 px-2 py-1 text-xs bg-gradient-to-r from-yellow-600 to-yellow-400 text-black rounded-full">
                 BETA
               </span>


### PR DESCRIPTION
## Summary
- remove the "Ape Fun" text next to the logo in the header

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851260eae9883278314335ec6356608