### PR TITLE
Add use client to footer

### DIFF
--- a/launch-fun-frontend/components/Footer.tsx
+++ b/launch-fun-frontend/components/Footer.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { FC } from 'react'
 import { motion } from 'framer-motion'
 import Link from 'next/link'


### PR DESCRIPTION
## Summary
- enable client-side rendering for footer

## Testing
- `npm install` in `launch-fun-frontend`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68512bdf0bf48327b8970570a1acba3d