### PR TITLE
Use bonding curve helpers for output estimates

### DIFF
--- a/launch-fun-frontend/app/token/[mint]/page.tsx
+++ b/launch-fun-frontend/app/token/[mint]/page.tsx
@@ -8,6 +8,7 @@ import { useWallet } from '@solana/wallet-adapter-react'
 import { useWalletModal } from '@solana/wallet-adapter-react-ui'
 import { Connection, PublicKey, Transaction, SystemProgram, LAMPORTS_PER_SOL } from '@solana/web3.js'
 import { getPlatformToken, updateTokenPrice } from '@/lib/tokenRegistry'
+import { estimateBuyTokens, estimateSellReturn } from '@/lib/bondingCurve'
 import * as Toast from '@radix-ui/react-toast'
 import { ArrowUpRight, ArrowDownRight, TrendingUp, Users, DollarSign, Activity } from 'lucide-react'
 
@@ -153,7 +154,7 @@ export default function TokenPage() {
       })
   }, [])
 
-  // Calculate estimated output based on bonding curve
+  // Calculate estimated output using bonding curve helpers
   useEffect(() => {
     if (!amount || !token) {
       setEstimatedOutput(0)
@@ -166,15 +167,11 @@ export default function TokenPage() {
       return
     }
 
-    // Simple bonding curve calculation
-    // In production, this would use the actual bonding curve formula
     if (tradeType === 'buy') {
-      // Buying tokens with SOL
-      const tokensOut = inputAmount / token.price
+      const tokensOut = estimateBuyTokens(token.price, inputAmount)
       setEstimatedOutput(tokensOut)
     } else {
-      // Selling tokens for SOL
-      const solOut = inputAmount * token.price
+      const solOut = estimateSellReturn(token.price, inputAmount)
       setEstimatedOutput(solOut)
     }
   }, [amount, token, tradeType])

--- a/launch-fun-frontend/lib/bondingCurve.ts
+++ b/launch-fun-frontend/lib/bondingCurve.ts
@@ -1,0 +1,11 @@
+export function estimateBuyTokens(price: number, solAmount: number): number {
+  if (price <= 0 || solAmount <= 0) return 0
+  // Placeholder bonding curve logic - simple proportional price
+  return solAmount / price
+}
+
+export function estimateSellReturn(price: number, tokenAmount: number): number {
+  if (price <= 0 || tokenAmount <= 0) return 0
+  // Placeholder bonding curve logic - simple proportional price
+  return tokenAmount * price
+}


### PR DESCRIPTION
## Summary
- add simple bonding curve helper module
- update token mint page to use bonding curve helpers when estimating

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685130b004b08327b1a23b3bda924495