### PR TITLE
Fix wallet adapter import

### DIFF
--- a/launch-fun-frontend/components/WalletProvider.tsx
+++ b/launch-fun-frontend/components/WalletProvider.tsx
@@ -4,7 +4,7 @@ import { FC, ReactNode, useMemo } from 'react'
 import { ConnectionProvider, WalletProvider as SolanaWalletProvider } from '@solana/wallet-adapter-react'
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui'
 import { PhantomWalletAdapter, SolflareWalletAdapter } from '@solana/wallet-adapter-wallets'
-import { MobileWalletAdapter } from '@solana-mobile/wallet-adapter-mobile'
+import { SolanaMobileWalletAdapter } from '@solana-mobile/wallet-adapter-mobile'
 import { clusterApiUrl } from '@solana/web3.js'
 
 // Import wallet adapter CSS
@@ -21,7 +21,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({ children }) => {
   const wallets = useMemo(
     () => [
       new PhantomWalletAdapter(),
-      new MobileWalletAdapter(),
+      new SolanaMobileWalletAdapter(),
       new SolflareWalletAdapter(),
     ],
     []


### PR DESCRIPTION
## Summary
- use `SolanaMobileWalletAdapter` class instead of `MobileWalletAdapter`
- instantiate new `SolanaMobileWalletAdapter` in wallet list
- ensure file ends with newline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68513ecba78c832795e99beaf298b55c