### PR TITLE
Persist launched tokens on client

### DIFF
--- a/launch-fun-frontend/app/api/tokens/create/route.ts
+++ b/launch-fun-frontend/app/api/tokens/create/route.ts
@@ -9,7 +9,6 @@ import {
   createSetAuthorityInstruction,
   AuthorityType
 } from '@solana/spl-token'
-import { savePlatformToken } from '@/lib/tokenRegistry'
 // TODO: add metadata creation using @metaplex-foundation/mpl-token-metadata
 
 // Platform configuration
@@ -213,25 +212,7 @@ export async function POST(request: NextRequest) {
     // Add mint keypair as signer
     transaction.partialSign(mintKeypair)
     
-    // Save token to registry with metadata
-    savePlatformToken({
-      mint: mint.toBase58(),
-      name,
-      symbol,
-      decimals,
-      totalSupply,
-      description,
-      imageUrl: imageUrl || '',
-      creator: creator,
-      createdAt: new Date().toISOString(),
-      price: 0.000001, // Initial price
-      priceChange24h: 0,
-      marketCap: 1000, // Initial market cap
-      volume24h: 0,
-      holders: 1,
-      bondingCurveProgress: 0,
-      salesTax: PLATFORM_CONFIG.salesTax
-    })
+    // Save token to registry on the client after transaction confirmation
     
     // Return the transaction for the user to sign
     return NextResponse.json({

--- a/launch-fun-frontend/app/create/page.tsx
+++ b/launch-fun-frontend/app/create/page.tsx
@@ -6,6 +6,8 @@ import { Header } from '@/components/Header'
 import { useWallet } from '@solana/wallet-adapter-react'
 import { useWalletModal } from '@solana/wallet-adapter-react-ui'
 import { Connection, PublicKey, Transaction } from '@solana/web3.js'
+import { savePlatformToken } from '@/lib/tokenRegistry'
+import { PLATFORM_CONFIG } from '@/lib/constants'
 import * as Toast from '@radix-ui/react-toast'
 import { Upload, X } from 'lucide-react'
 
@@ -210,6 +212,26 @@ export default function CreateToken() {
           `Token launched successfully! Mint: ${mintAddress.slice(0, 8)}...`,
           'success'
         )
+
+        // Persist the new token in localStorage
+        savePlatformToken({
+          mint: mintAddress,
+          name: formData.name,
+          symbol: formData.symbol,
+          description: formData.description,
+          imageUrl: imageUrl,
+          creator: publicKey.toBase58(),
+          totalSupply: formData.totalSupply,
+          decimals: formData.decimals,
+          createdAt: new Date().toISOString(),
+          price: 0.000001,
+          priceChange24h: 0,
+          marketCap: 1000,
+          volume24h: 0,
+          holders: 1,
+          bondingCurveProgress: 0,
+          salesTax: PLATFORM_CONFIG.salesTax
+        })
         
         // Open token page in new tab
         window.open(`/token/${mintAddress}`, '_blank')


### PR DESCRIPTION
## Summary
- store new tokens in localStorage when creation succeeds
- avoid saving tokens server-side to prevent duplicates

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c07ea37c8327a960ea261f4e4773