### PR TITLE
Implement metadata PDA creation

### DIFF
--- a/launch-fun-frontend/app/api/tokens/create/route.ts
+++ b/launch-fun-frontend/app/api/tokens/create/route.ts
@@ -10,7 +10,7 @@ import {
   AuthorityType
 } from '@solana/spl-token'
 import { savePlatformToken } from '@/lib/tokenRegistry'
-// TODO: add metadata creation using @metaplex-foundation/mpl-token-metadata
+import { createCreateMetadataAccountV3Instruction } from '@metaplex-foundation/mpl-token-metadata'
 
 // Platform configuration
 const PLATFORM_CONFIG = {
@@ -150,9 +150,50 @@ export async function POST(request: NextRequest) {
         creatorAllocation
       )
     )
-    
+
+    // Construct metadata URI using our API endpoint
+    const metadataUri = `${process.env.NEXT_PUBLIC_APP_URL || 'https://launch.fun'}/api/metadata/${mint.toBase58()}`
+
+    // Derive metadata PDA for the mint
+    const [metadataPDA] = PublicKey.findProgramAddressSync(
+      [
+        Buffer.from('metadata'),
+        TOKEN_METADATA_PROGRAM_ID.toBuffer(),
+        mint.toBuffer()
+      ],
+      TOKEN_METADATA_PROGRAM_ID
+    )
+
+    // Create on-chain metadata account before revoking mint authority
+    transaction.add(
+      createCreateMetadataAccountV3Instruction(
+        {
+          metadata: metadataPDA,
+          mint,
+          mintAuthority: creatorPubkey,
+          payer: creatorPubkey,
+          updateAuthority: creatorPubkey
+        },
+        {
+          createMetadataAccountArgsV3: {
+            data: {
+              name,
+              symbol,
+              uri: metadataUri,
+              sellerFeeBasisPoints: 0,
+              creators: null,
+              collection: null,
+              uses: null
+            },
+            isMutable: true,
+            collectionDetails: null
+          }
+        }
+      )
+    )
+
     // No initial platform allocation - fees collected on trades
-    
+
     // Remove mint authority (renounce minting)
     transaction.add(
       createSetAuthorityInstruction(
@@ -189,22 +230,6 @@ export async function POST(request: NextRequest) {
       }]
     }
 
-    // For now, we'll use our API endpoint as metadata URI
-    // In production, this should be uploaded to IPFS or Arweave
-    const metadataUri = `${process.env.NEXT_PUBLIC_APP_URL || 'https://launch.fun'}/api/metadata/${mint.toBase58()}`
-    
-    // Create metadata account - this must come AFTER mint initialization and BEFORE removing mint authority
-    const [metadataPDA] = PublicKey.findProgramAddressSync(
-      [
-        Buffer.from('metadata'),
-        TOKEN_METADATA_PROGRAM_ID.toBuffer(),
-        mint.toBuffer()
-      ],
-      TOKEN_METADATA_PROGRAM_ID
-    )
-
-    // Metadata creation is not implemented in this test build
-    
     // Get recent blockhash
     const { blockhash } = await connection.getLatestBlockhash()
     transaction.recentBlockhash = blockhash
@@ -239,7 +264,8 @@ export async function POST(request: NextRequest) {
       transaction: transaction.serialize({ requireAllSignatures: false }).toString('base64'),
       mint: mint.toBase58(),
       message: `Token created successfully with on-chain metadata!`,
-      metadataUri: metadataUri
+      metadataUri: metadataUri,
+      metadataPda: metadataPDA.toBase58()
     })
   } catch (error: any) {
     console.error('Error creating token:', error)


### PR DESCRIPTION
## Summary
- create on-chain metadata with createMetadataAccountV3
- export metadata PDA in create token API

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852cce8c270832789708d6ebd5a2b13